### PR TITLE
Resolve Outbound Deadlock Issue

### DIFF
--- a/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
+++ b/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
@@ -69,13 +69,13 @@ public abstract class AbstractEslClientHandler extends SimpleChannelInboundHandl
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception {
-
+		Throwable cause = e.getCause() == null ?  e : e.getCause();
 		for (final CompletableFuture<EslMessage> apiCall : apiCalls) {
-			apiCall.completeExceptionally(e.getCause());
+			apiCall.completeExceptionally(cause);
 		}
 
 		for (final CompletableFuture<EslEvent> backgroundJob : backgroundJobs.values()) {
-			backgroundJob.completeExceptionally(e.getCause());
+			backgroundJob.completeExceptionally(cause);
 		}
 
 		ctx.close();
@@ -198,6 +198,7 @@ public abstract class AbstractEslClientHandler extends SimpleChannelInboundHandl
 		final CompletableFuture<EslMessage> future = new CompletableFuture<>();
 		try {
 			syncLock.lock();
+			log.debug("Putting into apiCalls");
 			apiCalls.add(future);
 			channel.write(sb.toString());
             channel.flush();

--- a/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
+++ b/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
@@ -198,7 +198,6 @@ public abstract class AbstractEslClientHandler extends SimpleChannelInboundHandl
 		final CompletableFuture<EslMessage> future = new CompletableFuture<>();
 		try {
 			syncLock.lock();
-			log.debug("Putting into apiCalls");
 			apiCalls.add(future);
 			channel.write(sb.toString());
             channel.flush();

--- a/src/main/java/org/freeswitch/esl/client/outbound/OutboundChannelInitializer.java
+++ b/src/main/java/org/freeswitch/esl/client/outbound/OutboundChannelInitializer.java
@@ -4,6 +4,8 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringEncoder;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.freeswitch.esl.client.transport.message.EslFrameDecoder;
 
 import java.util.concurrent.ExecutorService;
@@ -12,7 +14,8 @@ import java.util.concurrent.Executors;
 public class OutboundChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private final IClientHandlerFactory clientHandlerFactory;
-    private ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+    private ExecutorService callbackExecutor = Executors.newFixedThreadPool(2);
+    private EventExecutorGroup group = new DefaultEventExecutorGroup(32);
 
     public OutboundChannelInitializer(IClientHandlerFactory clientHandlerFactory) {
         this.clientHandlerFactory = clientHandlerFactory;
@@ -32,7 +35,7 @@ public class OutboundChannelInitializer extends ChannelInitializer<SocketChannel
         pipeline.addLast("decoder", new EslFrameDecoder(8092, true));
 
         // now the outbound client logic
-        pipeline.addLast("clientHandler",
+        pipeline.addLast(group , "clientHandler",
                 new OutboundClientHandler(
                         clientHandlerFactory.createClientHandler(),
                         callbackExecutor));

--- a/src/main/java/org/freeswitch/esl/client/outbound/OutboundClientHandler.java
+++ b/src/main/java/org/freeswitch/esl/client/outbound/OutboundClientHandler.java
@@ -52,15 +52,16 @@ class OutboundClientHandler extends AbstractEslClientHandler {
 		// Have received a connection from FreeSWITCH server, send connect response
 		log.debug("Received new connection from server, sending connect message");
 
-		sendApiSingleLineCommand(ctx.channel(), "connect")
-				.thenAccept(response -> clientHandler.onConnect(
-						new Context(ctx.channel(), OutboundClientHandler.this),
-						new EslEvent(response, true)))
-				.exceptionally(throwable -> {
-					ctx.channel().close();
-					handleDisconnectionNotice();
-					return null;
-				});
+        sendApiSingleLineCommand(ctx.channel(), "connect")
+                .thenAccept(response ->
+                        callbackExecutor.execute(() -> clientHandler.onConnect(
+                                new Context(ctx.channel(), OutboundClientHandler.this),
+                                new EslEvent(response, true)))
+                ).exceptionally(throwable -> {
+            ctx.channel().close();
+            handleDisconnectionNotice();
+            return null;
+        });
 	}
 
 	@Override


### PR DESCRIPTION
The deadlock used to happen due to the `clientHandler.onConnect` handler being run on a sync thread. Hence any sync method would get blocked. AsyncApi still used to work, but the example provided was broken. With `onConnect` running on a separate thread the netty handler is released for further processing of responses which would complete the pending future.

Resolve #13
