### PR TITLE
Fix inbound ESL reconnection authentication status

### DIFF
--- a/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -98,6 +98,9 @@ public class Client implements IModEslApi {
 			close();
 		}
 
+		// Set or reset authentication status
+		authenticated = false;
+
 		log.info("Connecting to {} ...", clientAddress);
 
 		EventLoopGroup workerGroup = new NioEventLoopGroup();


### PR DESCRIPTION
On reconnect Client's method canSend() can return true before authentication is performed.
This can not happen at the first connection because authenticated is false by default.