### PR TITLE
ESLFrameDecoder Memory Leak and Outbound Deadlock Issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,13 +8,13 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-     maven { url "http://repo.maven.apache.org/maven2" }
+    mavenCentral()
 }
 
 dependencies {
-    compile 'io.netty:netty-all:4.1.17.Final'
-    compile 'com.google.guava:guava:23.4-jre'
-    compile 'org.slf4j:slf4j-api:1.7.25'
+    compile 'io.netty:netty-all:4.1.76.Final'
+    compile 'com.google.guava:guava:29.0-jre'
+    compile 'org.slf4j:slf4j-api:1.7.30'
     runtime 'ch.qos.logback:logback-classic:1.2.3'
     testCompile 'junit:junit:4.8.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip

--- a/src/main/java/org/freeswitch/esl/client/inbound/InboundChannelInitializer.java
+++ b/src/main/java/org/freeswitch/esl/client/inbound/InboundChannelInitializer.java
@@ -23,10 +23,9 @@ class InboundChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
         ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast("encoder", new StringEncoder());
         pipeline.addLast("decoder", new EslFrameDecoder(8192));
-
         // now the inbound client logic
         pipeline.addLast("clientHandler", handler);
-        pipeline.addLast("encoder", new StringEncoder());
     }
 }

--- a/src/main/java/org/freeswitch/esl/client/outbound/OutboundChannelInitializer.java
+++ b/src/main/java/org/freeswitch/esl/client/outbound/OutboundChannelInitializer.java
@@ -4,23 +4,24 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringEncoder;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.freeswitch.esl.client.transport.message.EslFrameDecoder;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class OutboundChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private final IClientHandlerFactory clientHandlerFactory;
-    private ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+    private final EventExecutorGroup customLogicExecutor;
 
-    public OutboundChannelInitializer(IClientHandlerFactory clientHandlerFactory) {
+    public OutboundChannelInitializer(IClientHandlerFactory clientHandlerFactory, int outboundEventThreadCount) {
         this.clientHandlerFactory = clientHandlerFactory;
-    }
-
-    public OutboundChannelInitializer setCallbackExecutor(ExecutorService callbackExecutor) {
-        this.callbackExecutor = callbackExecutor;
-        return this;
+        this.customLogicExecutor = new DefaultEventExecutorGroup(outboundEventThreadCount, new OutboundClientEventThreadFactory());
     }
 
     @Override
@@ -32,9 +33,36 @@ public class OutboundChannelInitializer extends ChannelInitializer<SocketChannel
         pipeline.addLast("decoder", new EslFrameDecoder(8092, true));
 
         // now the outbound client logic
-        pipeline.addLast("clientHandler",
+        pipeline.addLast(this.customLogicExecutor, "clientHandler",
                 new OutboundClientHandler(
                         clientHandlerFactory.createClientHandler(),
                         callbackExecutor));
+    }
+
+    static class OutboundClientEventThreadFactory implements ThreadFactory {
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        OutboundClientEventThreadFactory() {
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() :
+                    Thread.currentThread().getThreadGroup();
+            namePrefix = "outboundClientEventExecutor-" +
+                    poolNumber.getAndIncrement() +
+                    "-thread-";
+        }
+
+        public Thread newThread(Runnable runnable) {
+            Thread rabbitmqTaskWorker = new Thread(group, runnable,
+                    namePrefix + threadNumber.getAndIncrement(),
+                    0);
+            if (rabbitmqTaskWorker.isDaemon())
+                rabbitmqTaskWorker.setDaemon(false);
+            if (rabbitmqTaskWorker.getPriority() != Thread.NORM_PRIORITY)
+                rabbitmqTaskWorker.setPriority(Thread.NORM_PRIORITY);
+            return rabbitmqTaskWorker;
+        }
     }
 }

--- a/src/main/java/org/freeswitch/esl/client/outbound/SocketClient.java
+++ b/src/main/java/org/freeswitch/esl/client/outbound/SocketClient.java
@@ -40,10 +40,12 @@ import java.net.SocketAddress;
 public class SocketClient extends AbstractService {
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private static final int DEFAULT_OUTBOUND_EVENT_EXECUTOR_THREAD_COUNT = 32;
 	private final EventLoopGroup bossGroup;
 	private final EventLoopGroup workerGroup;
 	private final IClientHandlerFactory clientHandlerFactory;
 	private final SocketAddress bindAddress;
+	private final int outboundEventExecutorThreadCount;
 
 	private Channel serverChannel;
 
@@ -52,6 +54,14 @@ public class SocketClient extends AbstractService {
 		this.clientHandlerFactory = clientHandlerFactory;
 		this.bossGroup = new NioEventLoopGroup();
 		this.workerGroup = new NioEventLoopGroup();
+		this.outboundEventExecutorThreadCount = DEFAULT_OUTBOUND_EVENT_EXECUTOR_THREAD_COUNT;
+	}
+	public SocketClient(SocketAddress bindAddress, IClientHandlerFactory clientHandlerFactory, int outboundEventExecutorThreadCount) {
+		this.bindAddress = bindAddress;
+		this.clientHandlerFactory = clientHandlerFactory;
+		this.bossGroup = new NioEventLoopGroup();
+		this.workerGroup = new NioEventLoopGroup();
+		this.outboundEventExecutorThreadCount = outboundEventExecutorThreadCount;
 	}
 
 	@Override
@@ -59,7 +69,7 @@ public class SocketClient extends AbstractService {
 		final ServerBootstrap bootstrap = new ServerBootstrap()
 				.group(bossGroup, workerGroup)
 				.channel(NioServerSocketChannel.class)
-				.childHandler(new OutboundChannelInitializer(clientHandlerFactory))
+				.childHandler(new OutboundChannelInitializer(clientHandlerFactory, outboundEventExecutorThreadCount))
 				.childOption(ChannelOption.TCP_NODELAY, true)
 				.childOption(ChannelOption.SO_KEEPALIVE, true);
 

--- a/src/main/java/org/freeswitch/esl/client/transport/message/EslFrameDecoder.java
+++ b/src/main/java/org/freeswitch/esl/client/transport/message/EslFrameDecoder.java
@@ -136,7 +136,7 @@ public class EslFrameDecoder extends ReplayingDecoder<EslFrameDecoder.State> {
 								*   read the content-length specified
 								*/
 				int contentLength = currentMessage.getContentLength();
-				ByteBuf bodyBytes = buffer.readBytes(contentLength);
+				ByteBuf bodyBytes = buffer.readSlice(contentLength);
 				log.debug("read [{}] body bytes", bodyBytes.writerIndex());
 				// most bodies are line based, so split on LF
 				while (bodyBytes.isReadable()) {


### PR DESCRIPTION
Motivation:
The problem with ESLFrameDecoder is creating another byteBuff with readBytes but doesn't release it. 
**Change:** The reference count of the new bytebuff is aligned with the existing ones from the ReplayingDecoder(We can also call RefrenceCountUtil for that bytebuf rather than replace readBytes with readslices).

Another problem with outbound phases. Whenever a user tries to run any command with the given context. It uses a netty event-loop thread. Which causes a possible deadlock issue.

LEAK TRACE:
2022-04-27 08:02:44.633 ERROR 8 --- [ntLoopGroup-2-1] io.netty.util.ResourceLeakDetector       : LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
Created at:
        io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:349)
        io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:187)
        io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:123)
        io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:879)
        io.netty.handler.codec.ReplayingDecoderByteBuf.readBytes(ReplayingDecoderByteBuf.java:577)
        org.freeswitch.esl.client.transport.message.EslFrameDecoder.decode(EslFrameDecoder.java:139)
        io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:505)
        io.netty.handler.codec.ReplayingDecoder.callDecode(ReplayingDecoder.java:366)
        io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:283)
        io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374)
        io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360)
        io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:352)
        io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1421)
        io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:374)
        io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:360)
        io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:930)
        io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
        io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:697)
        io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:632)
        io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:549)
        io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:511)
        io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:918)
        io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        java.lang.Thread.run(Thread.java:748)